### PR TITLE
Update scuttlebutt@~5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "email": "raynos2@gmail.com"
   },
   "dependencies": {
-    "scuttlebutt": "~5.0.0"
+    "scuttlebutt": "~5.5"
   },
   "devDependencies": {
     "tap": "~0.3.1",


### PR DESCRIPTION
updating to scuttlebutt 5.5 will enable memory management in level-scuttlebutt,
doing so with a slightly open range (~...) will mean I will not have to issue a PR for small scuttlebutt patches!)
If you merge this, I will provide this in the new scuttlebutt service.
